### PR TITLE
Add optional options hash.

### DIFF
--- a/lib/app_perf_rpm/instruments/active_record/adapters/postgresql.rb
+++ b/lib/app_perf_rpm/instruments/active_record/adapters/postgresql.rb
@@ -17,10 +17,10 @@ module AppPerfRpm
               name == 'ActiveRecord::SchemaMigration Load'
           end
 
-          def exec_query_with_trace(sql, name = nil, binds = [])
+          def exec_query_with_trace(sql, name = nil, binds = [], opts = {})
             if ::AppPerfRpm::Tracer.tracing?
               if ignore_trace?(name)
-                exec_query_without_trace(sql, name, binds)
+                exec_query_without_trace(sql, name, binds, opts)
               else
                 sanitized_sql = sanitize_sql(sql, :postgres)
 
@@ -30,11 +30,11 @@ module AppPerfRpm
                     "query" => sanitized_sql,
                     "name" => name
                   }
-                  exec_query_without_trace(sql, name, binds)
+                  exec_query_without_trace(sql, name, binds, opts)
                 end
               end
             else
-              exec_query_without_trace(sql, name, binds)
+              exec_query_without_trace(sql, name, binds, *args)
             end
           end
 


### PR DESCRIPTION
Default options is `{prepare: false}`

Details can be found here: https://github.com/rails/rails/blob/f4d1aa5310284ebceb51970140fa08f6c8ea19b6/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L571