### PR TITLE
Fix namespace name for Roda and Redis instruments

### DIFF
--- a/lib/app_perf_rpm/instruments/redis.rb
+++ b/lib/app_perf_rpm/instruments/redis.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AppPerf
+module AppPerfRpm
   module Instruments
     module Redis
       include AppPerfRpm::Utils
@@ -64,7 +64,7 @@ if ::AppPerfRpm.config.instrumentation[:redis][:enabled] &&
   defined?(::Redis)
   ::AppPerfRpm.logger.info "Initializing redis tracer."
 
-  ::Redis::Client.send(:include, ::AppPerf::Instruments::Redis)
+  ::Redis::Client.send(:include, ::AppPerfRpm::Instruments::Redis)
 
   ::Redis::Client.class_eval do
     alias_method :call_without_trace, :call

--- a/lib/app_perf_rpm/instruments/roda.rb
+++ b/lib/app_perf_rpm/instruments/roda.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module AppPerf
+module AppPerfRpm
   module Instruments
     module Roda
       def call_with_trace(&block)
@@ -40,7 +40,7 @@ end
 if defined?(::Roda) && ::AppPerfRpm.config.instrumentation[:roda][:enabled]
   ::AppPerfRpm.logger.info "Initializing roda tracer."
 
-  ::Roda::RodaPlugins::Base::InstanceMethods.send(:include, AppPerf::Instruments::Roda)
+  ::Roda::RodaPlugins::Base::InstanceMethods.send(:include, AppPerfRpm::Instruments::Roda)
   ::Roda::RodaPlugins::Base::InstanceMethods.class_eval do
     alias_method :call_without_trace, :call
     alias_method :call, :call_with_trace


### PR DESCRIPTION
The outer module for these two instruments was specified as AppPerf. This changes brings them in line with the rest of the instruments.